### PR TITLE
adding -f flag to stop 'patch' from asking any question

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -422,8 +422,12 @@ class Patches implements PluginInterface, EventSubscriberInterface
             foreach ($patch_levels as $patch_level) {
                 // Check whether the patch applies in its entirety, to avoid
                 // leftovers in case of partial success.
+                // Using --dry-run to test if the patch applies before really applying it
+                // this will prevent partial patches, this -f flag is used to stop 'patch'
+                // from asking any question.
+                // This works the same as --check in the git apply implementation above.
                 if ($this->executeCommand(
-                    "patch --dry-run %s --no-backup-if-mismatch -d %s < %s",
+                    "patch -f --dry-run %s --no-backup-if-mismatch -d %s < %s",
                     $patch_level,
                     $install_path,
                     $filename


### PR DESCRIPTION
Sometimes the --dry-run will go into interactive mode to ask if these patches are Reversed or not, using -f flag would force 'patch' to stop asking any question and return the result from --dry-run.

As documented in patch man-pages
>  -f  or  --force
>           Assume that the user knows exactly what he or she is doing, and do
>           not ask any questions.  Skip patches whose headers do not say
>           which file is to be patched; patch files even though they have the
>           wrong version for the Prereq: line in the patch; and assume that
>           patches are not reversed even if they look like they are.  This
>           option does not suppress commentary; use -s for that. 

Creating this pull request so it can update PR in https://github.com/cweagans/composer-patches/pull/202.

Thank You.